### PR TITLE
Service#url: add `fop` when bucket is public

### DIFF
--- a/lib/active_storage/service/qiniu_service.rb
+++ b/lib/active_storage/service/qiniu_service.rb
@@ -119,7 +119,7 @@ module ActiveStorage
                 Qiniu::Auth.authorize_download_url_2(domain, key, schema: protocol, fop: fop, expires_in: expires_in)
               else
                 url_encoded_key = CGI::escape(key)
-                "#{protocol}://#{domain}/#{url_encoded_key}"
+                "#{protocol}://#{domain}/#{url_encoded_key}?#{fop}"
               end
 
         payload[:url] = url


### PR DESCRIPTION
Fix: 当 bucket 为公开时使用 `disposition: :attachement` 没有效果

API: https://edgeapi.rubyonrails.org/classes/ActiveStorage/BlobsController.html#method-i-show