### PR TITLE
使用分片上传API

### DIFF
--- a/activestorage_qiniu.gemspec
+++ b/activestorage_qiniu.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
-  spec.add_runtime_dependency 'rails', '~> 5.1', '>= 5.1.6.2'
+  spec.add_runtime_dependency 'rails', '>= 5.1.6.2'
 
   spec.add_dependency 'qiniu', '~> 6.9'
   spec.add_dependency 'retries', '~> 0.0.5'

--- a/activestorage_qiniu.gemspec
+++ b/activestorage_qiniu.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rails', '~> 5.1', '>= 5.1.6.2'
 
   spec.add_dependency 'qiniu', '~> 6.9'
+  spec.add_dependency 'retries', '~> 0.0.5'
 end


### PR DESCRIPTION
在实际使用中发现如果文件大于100M，用qiniu sdk里的表单直传会失败，而且qiniu ruby sdk里面没有分片上传API的实现，所以这个patch改用了分片上传，将文件按七牛约定的4M大小分片进行上传。

另外还 fixed #17 