### PR TITLE
修复 ruby@3.0.0 URI.escape  fix #37 

### DIFF
--- a/lib/active_storage/service/qiniu_service.rb
+++ b/lib/active_storage/service/qiniu_service.rb
@@ -118,7 +118,7 @@ module ActiveStorage
         fop = if options[:fop].present?        # 内容预处理
                 options[:fop]
               elsif options[:disposition].to_s == 'attachment' # 下载附件
-                attname = URI.escape "#{options[:filename] || key}"
+                attname = URI.encode_www_form_component "#{options[:filename] || key}"
                 "attname=#{attname}"
               end
 


### PR DESCRIPTION
修复 ruby@3.0.0 URI.escape fix #37 NoMethodError: undefined method `escape' for URI:Module

Ruby@3.0.0 这个方法已经彻底被拿掉了，替换成 `URI.encode_www_form_component`