### PR TITLE
use Base64.urlsafe_encode64 (instead of  Base64.encode) to construct upload URL

### DIFF
--- a/lib/active_storage/service/qiniu_service.rb
+++ b/lib/active_storage/service/qiniu_service.rb
@@ -60,8 +60,8 @@ module ActiveStorage
             'mkfile',
             file_size,
             'key',
-            encode(key),
-            *(content_type ? ['mimeType', encode(content_type)] : [])
+            Base64.urlsafe_encode64(key),
+            *(content_type ? ['mimeType', Base64.urlsafe_encode64(content_type)] : [])
           ].join('/'),
           ctx_list.join(',')
         )
@@ -190,10 +190,6 @@ module ActiveStorage
       result = JSON.parse(response.body)
 
       result
-    end
-
-    def encode(value)
-      Base64.encode64(value).strip.gsub(/\+/, '-').gsub(%r{/}, '_')
     end
   end
 end


### PR DESCRIPTION
一些 mime type 可能会很长，例如 `.xlsx`, `.docx` 这类。`Base64.encode` 当生成的字符串超过76个时，会插入一个换行符，导致生成的网址无效而报错。

常见的 mime type 列表： https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types

原代码里的 `encode` 方法其实是重新实现了 `Base64.urlsafe_encode64`，但却没正确处理里面的换行符。
![image](https://user-images.githubusercontent.com/548609/111949372-9085d580-8b1b-11eb-884a-98dfc0af1cd4.png)

关联 PR: https://github.com/mycolorway/activestorage_qiniu/pull/18
